### PR TITLE
Fix error when getting radarr movie info

### DIFF
--- a/Scripts/Flow/Applications/Radarr/Radarr - Trigger Manual Import.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Trigger Manual Import.js
@@ -7,7 +7,7 @@ import { Radarr } from 'Shared/Radarr';
  * @help Performs Radarr import to the Movie
  * Run last after file move.
  * @author iBuSH
- * @revision 7
+ * @revision 8
  * @param {string} URL Radarr root URL and port (e.g. http://radarr:7878).
  * @param {string} ApiKey Radarr API Key.
  * @param {string} ImportPath The output path for import triggering (default Working File).

--- a/Scripts/Flow/Applications/Radarr/Radarr - Trigger Manual Import.js
+++ b/Scripts/Flow/Applications/Radarr/Radarr - Trigger Manual Import.js
@@ -28,7 +28,7 @@ function Script(URL, ApiKey, ImportPath, UseUnmappedPath, MoveMode, TimeOut) {
 
     /*── movieId detection ──────────────────────────────────*/
     const searchPattern = Variables.file.Orig.FileNameNoExtension;
-    let movieId = Variables['Radarr.movieId'] ?? Variables.MovieInfo.id ?? parseMovie(searchPattern, radarr) ?? null;
+    let movieId = Variables['Radarr.movieId'] ?? Variables.MovieInfo?.id ?? parseMovie(searchPattern, radarr) ?? null;
 
     Logger.ILog(`Radarr URL: ${URL}`);
     Logger.ILog(`Triggering Path: ${ImportPath}`);


### PR DESCRIPTION
This fixes an issue where Variables.MovieInfo being null is causing the entire import operation to fail. Just add a small null check before trying to get ID.

## CLA

[X] I agree that by opening a pull requests I am handing over copyright ownership of my work contained in that pull request to the FileFlows project and the project owner. My contribution will become licensed under the same license as the overall project.
